### PR TITLE
Remove storage_type column from ingredients table

### DIFF
--- a/supabase/migrations/20250525145533_initial_migration.sql
+++ b/supabase/migrations/20250525145533_initial_migration.sql
@@ -56,7 +56,6 @@ CREATE TABLE public.ingredients (
   price numeric,
   category text,
   id integer GENERATED ALWAYS AS IDENTITY NOT NULL,
-  storage_type character varying,
   storage_type_id integer REFERENCES public.storage_types(id),
   location_id integer NOT NULL,
   CONSTRAINT ingredients_pkey PRIMARY KEY (id),


### PR DESCRIPTION
Removed 'storage_type' column from ingredients table.